### PR TITLE
refactor: atualização de funções nos serviços de evento

### DIFF
--- a/api/v1/endpoints/evento.py
+++ b/api/v1/endpoints/evento.py
@@ -28,7 +28,7 @@ async def get_eventos(db: AsyncSession = Depends(get_session)):
 async def get(evento_id: int, db: AsyncSession = Depends(get_session)):
     return await get_evento(evento_id, db)
 
-@router.put("/{evento_id}", response_model=EventoResponseSchema, status_code=status.HTTP_202_ACCEPTED, responses={**auth_responses, **generate_not_found_response("Evento")})
+@router.patch("/{evento_id}", response_model=EventoResponseSchema, status_code=status.HTTP_202_ACCEPTED, responses={**auth_responses, **generate_not_found_response("Evento")})
 async def put(evento_id: int, evento: EventoUpdateSchema, db: AsyncSession = Depends(get_session), usuario_logado: Organizador = Depends(get_current_user)):
     return await update_evento(evento_id=evento_id, evento=evento, db=db, organizador_id=usuario_logado.id)
 

--- a/schemas/evento_schema.py
+++ b/schemas/evento_schema.py
@@ -15,7 +15,7 @@ class EventoSchema(EventoBaseSchema):
 class EventoUpdateSchema(BaseModel):
     nome: Optional[str] = None
     descricao: Optional[str] = None
-    data_inicio: Optional[datetime] = None
+    data_inicio: Optional[str] = None
     capacidade: Optional[int] = None
     
 class EventoResponseSchemaCompleto(BaseModel):


### PR DESCRIPTION
Atualizações

- Criação da função pegar_evento, para que outras funções que necessitem de buscar um evento através de um id sejam direcionadas para essa função.

- Atualização da função update_evento deixando o código mais limpo ao invés de ir em cada campo e verificando se tem dado para atualizar.

- Atualização no schema para  atualizar evento, no campo data_inicio, o correto é o valor vir em string.

- Atualização do verbo para atualização de eventos, passando a utilizar patch, que é o correto.