### PR TITLE
refactor: atualização de serviço do recurso participante

### DIFF
--- a/api/v1/endpoints/participante.py
+++ b/api/v1/endpoints/participante.py
@@ -25,8 +25,8 @@ async def post_inscricao(evento: InscricaoBaseSchema, db: AsyncSession = Depends
 async def get(db: AsyncSession = Depends(get_session), usuario_logado: Participante = Depends(get_current_user)):
     return await get_participante(participante_id=usuario_logado.id, db=db)
 
-@router.put("/", response_model=ParticipanteSchema, status_code=status.HTTP_202_ACCEPTED, responses={**auth_responses, **generate_not_found_response("Participante")})
-async def put(participante: ParticipanteUpdateSchema, db: AsyncSession = Depends(get_session), usuario_logado: Participante = Depends(get_current_user)):
+@router.patch("/", response_model=ParticipanteSchema, status_code=status.HTTP_202_ACCEPTED, responses={**auth_responses, **generate_not_found_response("Participante")})
+async def patch(participante: ParticipanteUpdateSchema, db: AsyncSession = Depends(get_session), usuario_logado: Participante = Depends(get_current_user)):
     return await update_participante(participante_id=usuario_logado.id, participante=participante, db=db)
 
 @router.delete("/", status_code=status.HTTP_204_NO_CONTENT, responses={**auth_responses, **generate_not_found_response("Participante")})

--- a/schemas/participante_schema.py
+++ b/schemas/participante_schema.py
@@ -1,10 +1,11 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import EmailStr, field_validator
 from uuid import UUID
 from datetime import datetime
 from utils.valida_telefone import valida_telefone
-from . import EventoBaseSchema, ParticipanteBaseSchema
+from . import ParticipanteBaseSchema
+from schemas.evento_schema import EventoResponseSchema
 
 class ParticipanteCreateSchema(ParticipanteBaseSchema):
     senha: str
@@ -26,7 +27,7 @@ class ParticipanteUpdateSchema(ParticipanteBaseSchema):
         return valida_telefone(v)
 
 class ParticipanteEventosSchema(ParticipanteSchema):
-    eventos: List[EventoBaseSchema]
+    eventos: List[EventoResponseSchema]
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
Atualizações

Criação da função pegar_participante, para que outras funções que necessitem de buscar um evento através de um id sejam direcionadas para essa função.

Atualização da função update_participante deixando o código mais limpo ao invés de ir em cada campo e verificando se tem dado para atualizar.

Atualização no schema ParticipanteEventosSchema, para que receba uma lista de eventos com o schema EventoResponseSchema.

Atualização do verbo para atualização de eventos, passando a utilizar patch, que é o correto.